### PR TITLE
Fixed documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const nodes = [
     address: "localhost",
     password: "youshallnotpass",
     port: 2333,
-    ws: {}, // if you want to pass options to thw websocket.
+    ws: {}, // if you want to pass options to the websocket.
   },
 ];
 


### PR DESCRIPTION
Change "thw websocket" to "the websocket" in the README