### PR TITLE
Allow for `node.js v14 or newer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "typescript": "^4.1.2"
   },
   "engines": {
-    "node": "14.x.x"
+    "node": ">=14.x.x"
   }
 }


### PR DESCRIPTION
Fixed node engine requirements that prevented you from installing the lib on node 15.