### PR TITLE
Encode query on manager.search

### DIFF
--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -232,7 +232,7 @@ export class Manager extends EventEmitter {
       }
 
       const { request } = socket.secure ? https : http;
-      let res = request(`http${socket.secure ? "s" : ""}://${socket.address}/loadtracks?identifier=${query}`, {
+      let res = request(`http${socket.secure ? "s" : ""}://${socket.address}/loadtracks?identifier=${encodeURIComponent(query)}`, {
         headers: {
           authorization: socket.password,
         },


### PR DESCRIPTION
When the query is not encoded, Lavalink will not recognize extra youtube (and other) parameters like "list". Encoding it will fix it.