### PR TITLE
Fix:Manager options are overwritten by defaults

### DIFF
--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -71,7 +71,7 @@ export class Manager extends EventEmitter {
   constructor(nodes: SocketData[], options: ManagerOptions) {
     super();
 
-    options = Object.assign(options, defaults);
+    options = Object.assign(defaults, options);
 
     this.sockets = new Map();
     this.players = new Map();


### PR DESCRIPTION
Currently, when creating a manager, the following is used, which overwrites `shards`, `reconnect` and `resuming` properties.
```js
Object.assign(options, defaults)
``` 
This PR changes it to the below, meaning that you are able to override the default settings.
```js
Object.assign(defaults, options)
```