### PR TITLE
fix: "move" event emits when bot disconnects

### DIFF
--- a/src/structures/Manager.ts
+++ b/src/structures/Manager.ts
@@ -169,7 +169,7 @@ export class Manager extends EventEmitter {
   async stateUpdate(update: DiscordVoiceState): Promise<void> {
     const player = this.players.get(update.guild_id);
     if (player && update.user_id === this.userId) {
-      if (update.channel_id !== player.channel) {
+      if (update.channel_id && update.channel_id !== player.channel) {
         player.emit("move", update.channel_id);
         player.channel = update.channel_id!;
       }


### PR DESCRIPTION
Currently, the player emits the `move` event even when the bot just disconnects from the voice channel. Not sure if this is intentional, but I don't think it should be. This PR adds a null check for `update.channel_id` to ensure the bot actually switched channels before emitting the event.