### PR TITLE
feat: add Player#updated event

### DIFF
--- a/src/lib/Player.ts
+++ b/src/lib/Player.ts
@@ -297,6 +297,7 @@ export type PlayOptions = Omit<PlayData, "track">;
 
 export interface PlayerEvents {
     disconnected: (code: number, reason: string, byRemote: boolean) => void;
+    updated:() => void;
     trackStart: (track: string) => void;
     trackEnd: (track: string | null, reason: TrackEndReason) => void;
     trackException: (track: string | null, error: Error) => void;

--- a/src/lib/Player.ts
+++ b/src/lib/Player.ts
@@ -297,7 +297,7 @@ export type PlayOptions = Omit<PlayData, "track">;
 
 export interface PlayerEvents {
     disconnected: (code: number, reason: string, byRemote: boolean) => void;
-    updated:() => void;
+    updated: () => void;
     trackStart: (track: string) => void;
     trackEnd: (track: string | null, reason: TrackEndReason) => void;
     trackException: (track: string | null, error: Error) => void;

--- a/src/lib/node/Connection.ts
+++ b/src/lib/node/Connection.ts
@@ -222,7 +222,7 @@ export class Connection {
                     player.lastPosition = payload.state.position;
                     player.lastUpdate = Date.now();
 
-                    player.emit("updated")
+                    player.emit("updated");
                 } else {
                     player.handleEvent(payload);
                 }

--- a/src/lib/node/Connection.ts
+++ b/src/lib/node/Connection.ts
@@ -221,6 +221,8 @@ export class Connection {
                     player.lastLatency = payload.state.ping ?? -1; // depending on the version of lavalink this may be undefined
                     player.lastPosition = payload.state.position;
                     player.lastUpdate = Date.now();
+
+                    player.emit("updated")
                 } else {
                     player.handleEvent(payload);
                 }


### PR DESCRIPTION
Add `updated` event to `Player` which gets emitted when `playerUpdated` op received, so we can do

```
player.on("updated", () => {
  // do something with player
});
```
instead of
```
node.on("raw", (e) => {
    if (e.op !== "playerUpdate") return;
    
    const player = node.players.get(e.guildId);
    // do something with player
});